### PR TITLE
Correct location of Pagerduty handler

### DIFF
--- a/sensu/files/handlers/pagerduty.json
+++ b/sensu/files/handlers/pagerduty.json
@@ -7,7 +7,7 @@
       {%- if handler.mutator is defined %}
       "mutator": "{{ handler.mutator }}",
       {%- endif %}
-      "command": "/etc/sensu/handlers/handler-pagerduty.rb",
+      "command": "/etc/sensu/handlers/pagerduty.rb",
       "severities": [
         "ok",
         "critical",


### PR DESCRIPTION
Handler command was incorrectly specified as /etc/sensu/handlers/handler-pagerduty.rb instead of /etc/sensu/handlers/pagerduty.rb.